### PR TITLE
Adapt plugin to GitBook 3

### DIFF
--- a/_layouts/website/page.html
+++ b/_layouts/website/page.html
@@ -1,0 +1,6 @@
+{% extends template.self %}
+
+{% block body %}
+    <div class="fb_id" data-id="{{ config.pluginsConfig.facebook.appKey }}"></div>
+    {{ super() }}
+{% endblock %}

--- a/index.js
+++ b/index.js
@@ -8,13 +8,7 @@ module.exports = {
         js: [
             "https://connect.facebook.net/en_US/all.js",
             "facebook.js"
-        ],
-        html: {
-            "body:start": function() {
-                var appKey = this.options.pluginsConfig.facebook.appKey;
-                return '<div class="fb_id" data-id="' + appKey +'"></div>';
-            }
-        }
+        ]
     },
 
     hooks: {

--- a/index.js
+++ b/index.js
@@ -19,7 +19,7 @@ module.exports = {
 
     hooks: {
         "page": function(page) {
-            page.sections[0].content += '<br><div class="fb-comments" data-numposts="5" data-width="100%"></div>';
+            page.content += '<br><div class="fb-comments" data-numposts="5" data-width="100%"></div>';
             return page;
         }
     }

--- a/package.json
+++ b/package.json
@@ -14,5 +14,14 @@
     "license": "GPL-3.0",
     "bugs": {
         "url": "https://github.com/ymcatar/gitbook-plugin-facebook/issues"
+    },
+    "gitbook": {
+        "properties": {
+            "appKey": {
+                "type": "string",
+                "description": "Facebook Application ID",
+                "required": true
+            }
+        }
     }
 }


### PR DESCRIPTION
Hello,

We will soon release [GitBook v3](https://github.com/GitbookIO/gitbook).
The plugins API has been updated, as you will see [in the GitBook 3 documentation](http://toolchain.gitbook.com/).

I'm in charge of reviewing the existing plugins for maintaining the compatibility with this new version.
In this version, the hooks used for this plugin will not be supported, since we are relying a lot more on the templating system to extend the books HTML.

The proposed PR has been tested with the new version.
The `<div class="fb_id">` tag is now inserted using GitBook 3 templating. I also added the plugin configuration in the `package.json` for more security (the `appKey` is required for this plugin to work).
Finally, the `<div class="fb-comments">` is inserted using `page.content` which replaces the GitBook 2 `page.sections`.

Let me know if you have any remarks regarding what is done, and don't forget to publish a new version if you merge it :)

The new version's `package.json` should reflects the change on the gitbook engine:
```JSON
"engines": {
    "gitbook": ">=3.0.0-pre.0"
}
```

By the way, I also noticed that you had some test plugins (like `gitbook-plugin-facebooktest`).
Once you have a working plugin like this one, can you try to clean up the test versions to prevent users from using many versions, which will be hard to maintain over time?
Thanks!

Kind regards,
Johan